### PR TITLE
No JavaDoc required on ctors and test managment methods

### DIFF
--- a/checkstyle/Cortical_io_Checkstyle.xml
+++ b/checkstyle/Cortical_io_Checkstyle.xml
@@ -228,8 +228,9 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowedAnnotations" value="Override, Test, BeforeEach, AfterEach, BeforeAll, AfterAll, JsonIgnore, JsonCreator"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>


### PR DESCRIPTION
Just a proposal of Checkstyle change.
JavaDocs are no longer required on the following entities: 
* All **constructors** 
* Test management methods (with attributes like BeforeAll or AfterEach) 